### PR TITLE
feat: add fetch retry logic with progress notices

### DIFF
--- a/MMM-SooLocks.js
+++ b/MMM-SooLocks.js
@@ -4,6 +4,8 @@ Module.register('MMM-SooLocks', {
         showImages: false,
         numberOfShips: 5,
         fetchInterval: 30 * 60 * 1000,
+        maxRetries: 3,
+        retryDelay: 60 * 1000,
     },
 
     start: function () {
@@ -30,7 +32,11 @@ Module.register('MMM-SooLocks', {
     },
 
     getBoatInfo: function () {
-        this.sendSocketNotification('GET_BOAT_INFO', this.config.numberOfShips);
+        this.sendSocketNotification('GET_BOAT_INFO', {
+            numberOfShips: this.config.numberOfShips,
+            maxRetries: this.config.maxRetries,
+            retryDelay: this.config.retryDelay,
+        });
     },
 
     processBoatInfo: function (data) {
@@ -99,12 +105,12 @@ Module.register('MMM-SooLocks', {
 
     // socketNotificationReceived from helper
     socketNotificationReceived: function (notification, payload) {
+        let boatScheduleWrapper = document.getElementById('boatScheduleWrapper');
         if (notification === 'FAILED_TO_FETCH') {
-            let boatScheduleWrapper = document.getElementById(
-                'boatScheduleWrapper'
-            );
             boatScheduleWrapper.innerText = payload;
             boatScheduleWrapper.appendChild(this.getTimeStamp());
+        } else if (notification === 'FETCH_RETRY') {
+            boatScheduleWrapper.innerText = payload;
         } else if (notification === 'BOAT_LOCATIONS') {
             this.processBoatInfo(payload);
         } else {

--- a/README.md
+++ b/README.md
@@ -32,12 +32,29 @@ var config = {
             config: {
                 showImages: true,
                 numberOfShips: 5,
-                frequency: 30 * 60 * 1000,
+                fetchInterval: 30 * 60 * 1000,
+                maxRetries: 3,
+                retryDelay: 60 * 1000,
             },
         },
     ],
 };
 ```
+
+### Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `showImages` | `false` | Show vessel images when available. |
+| `numberOfShips` | `5` | Number of ships to display. |
+| `fetchInterval` | `30 * 60 * 1000` | How often to refresh data (in ms). |
+| `maxRetries` | `3` | Maximum number of fetch retries on failure. |
+| `retryDelay` | `60 * 1000` | Initial delay (ms) before a retry; doubles after each failure. |
+
+On a failed fetch the module will retry using exponential backoff. Progress
+messages such as "Retrying in 60s..." will be displayed on the frontend while
+waiting between attempts. After `maxRetries` attempts the module stops retrying
+until the next scheduled refresh.
 
 This is the only config setup for now. More features may be added in the future.
 

--- a/node_helper.js
+++ b/node_helper.js
@@ -10,7 +10,8 @@ module.exports = NodeHelper.create({
         Log.log(`Stopping module helper: ${this.name}`);
     },
 
-    async fetchBoatData(numberOfShips) {
+    async fetchBoatData(config) {
+        const { numberOfShips, maxRetries, retryDelay } = config;
         const nodeVersion = Number(process.version.match(/^v(\d+\.\d+)/)[1]);
         const headers = {
             'User-Agent': `Mozilla/5.0 (Node.js ${nodeVersion}) MagicMirror/${global.version}`,
@@ -19,24 +20,38 @@ module.exports = NodeHelper.create({
         };
         const url = `https://ais.boatnerd.com/passage/getPassageData?search=&sort=destination_eta&order=desc&offset=0&limit=${numberOfShips}&port=12`;
 
-        try {
-            const response = await fetch(url, { headers });
-            if (!response.ok) {
-                throw new Error(`HTTP error ${response.status}`);
+        const attemptFetch = async (attempt) => {
+            try {
+                const response = await fetch(url, { headers });
+                if (!response.ok) {
+                    throw new Error(`HTTP error ${response.status}`);
+                }
+                const data = await response.json();
+                if (!data || !Array.isArray(data.rows)) {
+                    throw new Error('Malformed data structure received');
+                }
+                Log.info('Pulling info...');
+                this.sendSocketNotification('BOAT_LOCATIONS', data);
+            } catch (err) {
+                if (attempt < maxRetries) {
+                    const delay = retryDelay * Math.pow(2, attempt);
+                    Log.error('Unable to fetch -', err, `Retrying in ${delay / 1000}s`);
+                    this.sendSocketNotification(
+                        'FETCH_RETRY',
+                        `Retrying in ${Math.round(delay / 1000)}s...`
+                    );
+                    setTimeout(() => attemptFetch(attempt + 1), delay);
+                } else {
+                    Log.error('********** Unable to fetch after retries -', err);
+                    this.sendSocketNotification(
+                        'FAILED_TO_FETCH',
+                        'Failed to get boat data.\nPlease restart device\nor wait until the next reload.'
+                    );
+                }
             }
-            const data = await response.json();
-            if (!data || !Array.isArray(data.rows)) {
-                throw new Error('Malformed data structure received');
-            }
-            Log.info('Pulling info...');
-            this.sendSocketNotification('BOAT_LOCATIONS', data);
-        } catch (err) {
-            Log.error('********** Unable to fetch -', err);
-            this.sendSocketNotification(
-                'FAILED_TO_FETCH',
-                'Failed to get boat data.\nPlease restart device\nor wait until the next reload.'
-            );
-        }
+        };
+
+        attemptFetch(0);
     },
 
     socketNotificationReceived: function (notification, payload) {


### PR DESCRIPTION
## Summary
- add exponential backoff retries with user-facing progress messages
- expose `maxRetries` and `retryDelay` config options
- document retry behaviour and config options

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check node_helper.js MMM-SooLocks.js`


------
https://chatgpt.com/codex/tasks/task_e_6896fba2c0148328af960322103c590f